### PR TITLE
MySQLWorkBench

### DIFF
--- a/Applications/MySQLWorkBench.download.recipe
+++ b/Applications/MySQLWorkBench.download.recipe
@@ -14,7 +14,7 @@
 				<string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
 	</dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>0.6.0</string>
     <key>Process</key>
     <array>
 		<dict>
@@ -23,7 +23,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://dev.mysql.com/downloads/workbench</string>
+                <string>https://dev.mysql.com/downloads/workbench</string>
                 <key>re_pattern</key>
                 <string>(?P&lt;dmg&gt;mysql-workbench-community-\S+dmg)</string>
                 <key>request_headers</key>
@@ -39,12 +39,23 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://dev.mysql.com/get/Downloads/MySQLGUITools/%dmg%</string>
+                <string>https://dev.mysql.com/get/Downloads/MySQLGUITools/%dmg%</string>
             </dict>
         </dict>
         <dict>
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+          <key>Arguments</key>
+          <dict>
+            <key>input_path</key>
+            <string>%pathname%/MySQLWorkbench.app</string>
+            <key>requirement</key>
+            <string>identifier "com.oracle.mysql.workbench" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "VB5E2TV963"</string>
+          </dict>
+          <key>Processor</key>
+          <string>CodeSignatureVerifier</string>
         </dict>
     </array>
 </dict>

--- a/Applications/MySQLWorkBench.download.recipe
+++ b/Applications/MySQLWorkBench.download.recipe
@@ -40,6 +40,8 @@
             <dict>
                 <key>url</key>
                 <string>https://dev.mysql.com/get/Downloads/MySQLGUITools/%dmg%</string>
+                <key>filename</key>
+                <string>%NAME%.dmg</string>
             </dict>
         </dict>
         <dict>

--- a/Applications/MySQLWorkBench.install.recipe
+++ b/Applications/MySQLWorkBench.install.recipe
@@ -12,7 +12,7 @@
 	<dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.4.0</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Applications/MySQLWorkBench.munki.recipe
+++ b/Applications/MySQLWorkBench.munki.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>ParentRecipe</key>
-    <string>com.github.autopkg.cgerke-recipes.pkg.MySQLWorkBench</string>
+    <string>com.github.autopkg.cgerke-recipes.download.MySQLWorkBench</string>
     <key>Description</key>
     <string>Builds MySQLWorkBench and imports into a Munki repo.</string>
     <key>Identifier</key>
@@ -31,19 +31,42 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>0.6.0</string>
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
             <key>Arguments</key>
             <dict>
-                <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
-                <key>repo_subdirectory</key>
-                <string>%MUNKI_REPO_SUBDIR%</string>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>installs</key>
+                    <array>
+                        <dict>
+                            <key>CFBundleIdentifier</key>
+                            <string>com.oracle.mysql.workbench</string>
+                            <key>CFBundleName</key>
+                            <string>MySQLWorkbench</string>
+                            <key>path</key>
+                            <string>/Applications/MySQLWorkbench.app</string>
+                            <key>type</key>
+                            <string>file</string>
+                        </dict>
+                    </array>
+                </dict>
             </dict>
-            <key>Processor</key>
-            <string>MunkiImporter</string>
+        </dict>
+        <dict>
+          <key>Processor</key>
+          <string>MunkiImporter</string>
+          <key>Arguments</key>
+          <dict>
+            <key>pkg_path</key>
+            <string>%pathname%</string>
+            <key>repo_subdirectory</key>
+            <string>%MUNKI_REPO_SUBDIR%</string>
+          </dict>
         </dict>
     </array>
 </dict>

--- a/Applications/MySQLWorkBench.pkg.recipe
+++ b/Applications/MySQLWorkBench.pkg.recipe
@@ -14,7 +14,7 @@
         <string>MySQLWorkBench</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>0.6.0</string>
     <key>Process</key>
     <array>
         <dict>

--- a/Applications/MySQLWorkBench.sccm.recipe
+++ b/Applications/MySQLWorkBench.sccm.recipe
@@ -14,7 +14,7 @@
 		<string>MySQLWorkBench</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.4.0</string>
+	<string>0.6.0</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
I've changed the following:
- Added SSL to downloads and CodeSignatureVerification on the application bundle.
- Remove munki recipe dependency on building a package (munki doesn't need a package to natively support this, unlike other tools) and re-factor for native support.
- Update remaining recipes to require Autopkg 0.6.0 due to the requirement for SSL validation on the download.

The second change is the only one that would probably impact people, however it uses the proper versioning of the application vs a custom pkg receipt.
