### PR TITLE
[MySQLWorkBench] Fix codesignatureverification identifier

### DIFF
--- a/Applications/MySQLWorkBench.download.recipe
+++ b/Applications/MySQLWorkBench.download.recipe
@@ -54,7 +54,7 @@
             <key>input_path</key>
             <string>%pathname%/MySQLWorkbench.app</string>
             <key>requirement</key>
-            <string>identifier "com.oracle.mysql.workbench" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "VB5E2TV963"</string>
+            <string>identifier "com.oracle.workbench.MySQLWorkbench" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = VB5E2TV963</string>
           </dict>
           <key>Processor</key>
           <string>CodeSignatureVerifier</string>


### PR DESCRIPTION
Fixes #12 

```
$ autopkg run MySQLWorkBench.download.recipe -v
Processing MySQLWorkBench.download.recipe...
URLTextSearcher
URLTextSearcher: Found matching text (match): mysql-workbench-community-6.3.9-osx-x86_64.dmg
URLTextSearcher: Found matching text (dmg): mysql-workbench-community-6.3.9-osx-x86_64.dmg
URLDownloader
URLDownloader: Storing new Last-Modified header: Mon, 06 Feb 2017 09:55:00 GMT
URLDownloader: Storing new ETag header: "a826ffc34e92216bb591b2a0659bc00b:1486487744"
URLDownloader: Downloaded /Users/cwhits/Library/AutoPkg/Cache/com.github.autopkg.cgerke-recipes.download.MySQLWorkBench/downloads/MySQLWorkBench.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/cwhits/Library/AutoPkg/Cache/com.github.autopkg.cgerke-recipes.download.MySQLWorkBench/downloads/MySQLWorkBench.dmg
CodeSignatureVerifier: Verifying application bundle signature...
CodeSignatureVerifier: /private/tmp/dmg.7CTSD8/MySQLWorkbench.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.7CTSD8/MySQLWorkbench.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.7CTSD8/MySQLWorkbench.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
Receipt written to /Users/cwhits/Library/AutoPkg/Cache/com.github.autopkg.cgerke-recipes.download.MySQLWorkBench/receipts/MySQLWorkBench.download-receipt-20170310-152930.plist

The following new items were downloaded:
    Download Path
    -------------
    /Users/cwhits/Library/AutoPkg/Cache/com.github.autopkg.cgerke-recipes.download.MySQLWorkBench/downloads/MySQLWorkBench.dmg
```