### PR TITLE
Add blocking application as I was able to uninstall while Wireshark was running...

### DIFF
--- a/Applications/Wireshark.munki.recipe
+++ b/Applications/Wireshark.munki.recipe
@@ -16,6 +16,10 @@
         <string>apps</string>
         <key>pkginfo</key>
         <dict>
+            <key>blocking_applications</key>
+			<array>
+			    <string>Wireshark</string>
+			</array>
             <key>catalogs</key>
             <array>
                 <string>testing</string>


### PR DESCRIPTION
and continued to run in memory until I quit the application.