### PR TITLE
Update Versioner input_plist_path

### DIFF
--- a/Applications/ChromeRemoteDesktop.pkg.recipe
+++ b/Applications/ChromeRemoteDesktop.pkg.recipe
@@ -47,7 +47,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/payload/Library/PreferencePanes/ChromeRemoteDesktop.prefPane/Contents/Info.plist</string>
+                <string>%RECIPE_CACHE_DIR%/payload/Library/PrivilegedHelperTools/ChromeRemoteDesktopHost.bundle/Contents/Info.plist</string>
                 <key>plist_version_key</key>
                 <string>CFBundleShortVersionString</string>
             </dict>


### PR DESCRIPTION
Chrome Remote Desktop no longer has a .prefpane item as part of payload.  Updates recipe to read from the PrivilegedHelperTools .bundle instead.

![screen shot 2018-03-11 at 6 48 04 pm](https://user-images.githubusercontent.com/11789931/37259671-83599f7e-255f-11e8-9ea6-35a384dd1838.png)
