### PR TITLE
Basic python3 compatibility

### DIFF
--- a/SharedProcessors/CmmacCreator.py
+++ b/SharedProcessors/CmmacCreator.py
@@ -22,11 +22,10 @@
 # figure out how to make this a shared processor
 
 from __future__ import absolute_import
+
 import os.path
 import subprocess
-import shutil
 
-from glob import glob
 from autopkglib import Processor, ProcessorError
 
 __all__ = ["CmmacCreator"]

--- a/SharedProcessors/CmmacCreator.py
+++ b/SharedProcessors/CmmacCreator.py
@@ -21,6 +21,7 @@
 # see comments throughout, there is a some todo items
 # figure out how to make this a shared processor
 
+from __future__ import absolute_import
 import os.path
 import subprocess
 import shutil

--- a/SharedProcessors/PkgDistributionCreator.py
+++ b/SharedProcessors/PkgDistributionCreator.py
@@ -19,6 +19,7 @@
 # chris.gerke@gmail.com
 # Borrowed code and concepts from FlatPkgUnpacker.py (Copyright 2013 Timothy Sutton) in the AutoPKG core.
 
+from __future__ import absolute_import
 import os.path
 import subprocess
 import shutil

--- a/SharedProcessors/PkgDistributionCreator.py
+++ b/SharedProcessors/PkgDistributionCreator.py
@@ -20,11 +20,10 @@
 # Borrowed code and concepts from FlatPkgUnpacker.py (Copyright 2013 Timothy Sutton) in the AutoPKG core.
 
 from __future__ import absolute_import
+
 import os.path
 import subprocess
-import shutil
 
-from glob import glob
 from autopkglib import Processor, ProcessorError
 
 __all__ = ["PkgDistributionCreator"]
@@ -78,7 +77,7 @@ class PkgDistributionCreator(Processor):
         if p.returncode != 0:
             raise ProcessorError("cmmac conversion of %s failed: %s"
                 % (self.env['source_path'], err))
-                
+
     def main(self):
         if os.path.exists(self.env['source_path']):
             try:

--- a/SharedProcessors/PkgDistributionInfoCreator.py
+++ b/SharedProcessors/PkgDistributionInfoCreator.py
@@ -20,11 +20,10 @@
 # Borrowed code and concepts from FlatPkgUnpacker.py (Copyright 2013 Timothy Sutton) in the AutoPKG core.
 
 from __future__ import absolute_import
+
 import os.path
 import subprocess
-import shutil
 
-from glob import glob
 from autopkglib import Processor, ProcessorError
 
 __all__ = ["PkgDistributionInfoCreator"]
@@ -69,7 +68,7 @@ class PkgDistributionInfoCreator(Processor):
         if p.returncode != 0:
             raise ProcessorError("productbuild conversion of %s failed: %s"
                 % (self.env['source_path'], err))
-                
+
     def main(self):
         if os.path.exists(self.env['source_path']):
             try:

--- a/SharedProcessors/PkgDistributionInfoCreator.py
+++ b/SharedProcessors/PkgDistributionInfoCreator.py
@@ -19,6 +19,7 @@
 # chris.gerke@gmail.com
 # Borrowed code and concepts from FlatPkgUnpacker.py (Copyright 2013 Timothy Sutton) in the AutoPKG core.
 
+from __future__ import absolute_import
 import os.path
 import subprocess
 import shutil


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later, but this should catch the low-hanging fruit right now.