### PR TITLE
Update Wireshark recipes for munki

### DIFF
--- a/Applications/Wireshark.download.recipe
+++ b/Applications/Wireshark.download.recipe
@@ -41,7 +41,7 @@
                 <key>url</key>
                 <string>https://www.wireshark.org/download/osx/%match%</string>
                 <key>filename</key>
-                <string>Wireshark.dmg</string>
+                <string>%NAME%.dmg</string>
             </dict>
         </dict>
         <dict>

--- a/Applications/Wireshark.munki.recipe
+++ b/Applications/Wireshark.munki.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>ParentRecipe</key>
-    <string>com.github.autopkg.cgerke-recipes.pkg.Wireshark</string>
+    <string>com.github.autopkg.cgerke-recipes.download.Wireshark</string>
     <key>Description</key>
     <string>Builds Wireshark and imports into a Munki repo.</string>
     <key>Identifier</key>
@@ -13,7 +13,7 @@
         <key>NAME</key>
         <string>Wireshark</string>
         <key>MUNKI_REPO_SUBDIR</key>
-        <string>apps</string>
+        <string>apps/wireshark</string>
         <key>pkginfo</key>
         <dict>
             <key>blocking_applications</key>
@@ -41,8 +41,10 @@
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>munkiimport_appname</key>
+                <string>Wireshark.app</string>
                 <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+                <string>%pathname%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>


### PR DESCRIPTION
- Have munki recipe use download as parent instead of pkg.  Doing it this way results in more detailed info about what's installed, including the minimum os version, which does not require building a pkg (I know this is required for other recipes, but not munki)
- Update MunkiImporter variables to point to app within the downloaded DMG.
- Use NAME input variable for filename in download recipe to be consistent with other recipes should the admin specify a different NAME value.

Verbose recipe output after changes:

```
autopkg run ~/Documents/git/cgerke-recipes/Applications/Wireshark.munki.recipe -vv
Processing /Users/admin/Documents/git/cgerke-recipes/Applications/Wireshark.munki.recipe...
WARNING: /Users/admin/Documents/git/cgerke-recipes/Applications/Wireshark.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(Wireshark([%]20)*.*([%]20)*Intel([%]20)*64.dmg)',
           'request_headers': {'User-Agent': 'Safari 8.0.2'},
           'result_output_var_name': 'match',
           'url': 'https://www.wireshark.org/download.html'}}
URLTextSearcher: Found matching text (match): Wireshark%203.2.7%20Intel%2064.dmg
{'Output': {'match': 'Wireshark%203.2.7%20Intel%2064.dmg'}}
URLDownloader
{'Input': {'filename': 'Wireshark.dmg',
           'request_headers': {'User-Agent': 'Safari 8.0.2'},
           'url': 'https://www.wireshark.org/download/osx/Wireshark%203.2.7%20Intel%2064.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/admin/Library/AutoPkg/Cache/com.github.autopkg.cgerke-recipes.munki.Wireshark/downloads/Wireshark.dmg
{'Output': {'pathname': '/Users/admin/Library/AutoPkg/Cache/com.github.autopkg.cgerke-recipes.munki.Wireshark/downloads/Wireshark.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/admin/Library/AutoPkg/Cache/com.github.autopkg.cgerke-recipes.munki.Wireshark/downloads/Wireshark.dmg/Wireshark*.app',
           'requirement': 'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"7Z6EMTD2C6"'}}
CodeSignatureVerifier: Mounted disk image /Users/admin/Library/AutoPkg/Cache/com.github.autopkg.cgerke-recipes.munki.Wireshark/downloads/Wireshark.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.wTtSx3/Wireshark.app' matched from globbed '/private/tmp/dmg.wTtSx3/Wireshark*.app'.
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.wTtSx3/Wireshark.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.wTtSx3/Wireshark.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.wTtSx3/Wireshark.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'munkiimport_appname': 'Wireshark.app',
           'pkg_path': '/Users/admin/Library/AutoPkg/Cache/com.github.autopkg.cgerke-recipes.munki.Wireshark/downloads/Wireshark.dmg',
           'pkginfo': {'blocking_applications': ['Wireshark'],
                       'catalogs': ['testing'],
                       'description': 'Wireshark is a network protocol '
                                      'analyzer.',
                       'display_name': 'Wireshark',
                       'name': 'Wireshark',
                       'unattended_install': True},
           'repo_subdirectory': 'apps/wireshark'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/wireshark/Wireshark-3.2.7.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/wireshark/Wireshark-3.2.7.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'Wireshark',
                                                       'pkg_repo_path': 'apps/wireshark/Wireshark-3.2.7.dmg',
                                                       'pkginfo_path': 'apps/wireshark/Wireshark-3.2.7.plist',
                                                       'version': '3.2.7'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'admin',
                                         'creation_date': datetime.datetime(2020, 10, 12, 13, 12, 25),
                                         'munki_version': '5.1.0.4107',
                                         'os_version': '10.15.6'},
                           'autoremove': False,
                           'blocking_applications': ['Wireshark'],
                           'catalogs': ['testing'],
                           'description': 'Wireshark is a network protocol '
                                          'analyzer.',
                           'display_name': 'Wireshark',
                           'installer_item_hash': '1347138534c6d9adb2ee1af7898cac2248b63bfb1ac6afee54e17725ab333106',
                           'installer_item_location': 'apps/wireshark/Wireshark-3.2.7.dmg',
                           'installer_item_size': 95442,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'org.wireshark.Wireshark',
                                         'CFBundleShortVersionString': '3.2.7',
                                         'CFBundleVersion': '3.2.7',
                                         'minosversion': '10.12',
                                         'path': '/Applications/Wireshark.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'Wireshark.app'}],
                           'minimum_os_version': '10.12',
                           'name': 'Wireshark',
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '3.2.7'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/wireshark/Wireshark-3.2.7.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/wireshark/Wireshark-3.2.7.plist'}}
Receipt written to /Users/admin/Library/AutoPkg/Cache/com.github.autopkg.cgerke-recipes.munki.Wireshark/receipts/Wireshark.munki-receipt-20201012-091226.plist

The following new items were imported into Munki:
    Name       Version  Catalogs  Pkginfo Path                          Pkg Repo Path                       Icon Repo Path  
    ----       -------  --------  ------------                          -------------                       --------------  
    Wireshark  3.2.7    testing   apps/wireshark/Wireshark-3.2.7.plist  apps/wireshark/Wireshark-3.2.7.dmg  
```