### PR TITLE
Adjust name of CodeSignatureVerifier argument

### DIFF
--- a/Applications/GNS3.download.recipe
+++ b/Applications/GNS3.download.recipe
@@ -48,7 +48,7 @@
             <dict>
                 <key>input_path</key>
                 <string>%pathname%/GNS3.app</string>
-                <key>requirements</key>
+                <key>requirement</key>
                 <string>identifier "net.gns3" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "5C3VHX9RG5"</string>
             </dict>
         </dict>


### PR DESCRIPTION
The correct argument name for [CodeSignatureVerifier](https://github.com/autopkg/autopkg/wiki/Processor-CodeSignatureVerifier) is `requirement`.