### PR TITLE
Adjust PkgCreator arguments

### DIFF
--- a/Applications/AWSCLI.pkg.recipe
+++ b/Applications/AWSCLI.pkg.recipe
@@ -107,10 +107,10 @@
                 <string>PkgCreator</string>
                 <key>Arguments</key>
                 <dict>
-                    <key>pkgname</key>
-                    <string>%NAME%-%version%</string>
                     <key>pkg_request</key>
                     <dict>
+                        <key>pkgname</key>
+                        <string>%NAME%-%version%</string>
                         <key>chown</key>
                         <array>
                             <dict>

--- a/Applications/AmazonEC2Tools.pkg.recipe
+++ b/Applications/AmazonEC2Tools.pkg.recipe
@@ -97,10 +97,10 @@
                 <string>PkgCreator</string>
                 <key>Arguments</key>
                 <dict>
-                    <key>pkgname</key>
-                    <string>%NAME%-%version%</string>
                     <key>pkg_request</key>
                     <dict>
+                        <key>pkgname</key>
+                        <string>%NAME%-%version%</string>
                         <key>chown</key>
                         <array>
                             <dict>

--- a/Applications/AutoDMG.pkg.recipe
+++ b/Applications/AutoDMG.pkg.recipe
@@ -56,10 +56,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Applications/GNS3.pkg.recipe
+++ b/Applications/GNS3.pkg.recipe
@@ -56,10 +56,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Applications/GoogleDrive.pkg.recipe
+++ b/Applications/GoogleDrive.pkg.recipe
@@ -56,10 +56,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Applications/MySQLWorkbench.pkg.recipe
+++ b/Applications/MySQLWorkbench.pkg.recipe
@@ -65,10 +65,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Applications/PIP.pkg.recipe
+++ b/Applications/PIP.pkg.recipe
@@ -72,10 +72,10 @@
 			<dict>
                 <key>force_pkg_build</key>
                 <string>true</string>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/Applications/Wireshark.pkg.recipe
+++ b/Applications/Wireshark.pkg.recipe
@@ -56,10 +56,10 @@
             <string>PkgCreator</string>
             <key>Arguments</key>
             <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
                 <key>pkg_request</key>
                 <dict>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>

--- a/Configurations/ConfigAirdrop.pkg.recipe
+++ b/Configurations/ConfigAirdrop.pkg.recipe
@@ -43,10 +43,10 @@
 			<dict>
                 <key>force_pkg_build</key>
                 <string>true</string>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>chown</key>
 					<array>
 					</array>

--- a/Configurations/ConfigAirportAdmin.pkg.recipe
+++ b/Configurations/ConfigAirportAdmin.pkg.recipe
@@ -43,10 +43,10 @@
 			<dict>
                 <key>force_pkg_build</key>
                 <string>true</string>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>chown</key>
 					<array>
 					</array>

--- a/Configurations/ConfigAuthorizationDateTime.pkg.recipe
+++ b/Configurations/ConfigAuthorizationDateTime.pkg.recipe
@@ -43,10 +43,10 @@
 			<dict>
                 <key>force_pkg_build</key>
                 <string>true</string>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>chown</key>
 					<array>
 					</array>

--- a/Configurations/ConfigAuthorizationEnergySaver.pkg.recipe
+++ b/Configurations/ConfigAuthorizationEnergySaver.pkg.recipe
@@ -43,10 +43,10 @@
 			<dict>
                 <key>force_pkg_build</key>
                 <string>true</string>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>chown</key>
 					<array>
 					</array>

--- a/Configurations/ConfigAuthorizationNetwork.pkg.recipe
+++ b/Configurations/ConfigAuthorizationNetwork.pkg.recipe
@@ -43,10 +43,10 @@
 			<dict>
                 <key>force_pkg_build</key>
                 <string>true</string>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>chown</key>
 					<array>
 					</array>

--- a/Configurations/ConfigAuthorizationPrint.pkg.recipe
+++ b/Configurations/ConfigAuthorizationPrint.pkg.recipe
@@ -43,10 +43,10 @@
 			<dict>
                 <key>force_pkg_build</key>
                 <string>true</string>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>chown</key>
 					<array>
 					</array>

--- a/Configurations/ConfigAuthorizationSharing.pkg.recipe
+++ b/Configurations/ConfigAuthorizationSharing.pkg.recipe
@@ -43,10 +43,10 @@
 			<dict>
                 <key>force_pkg_build</key>
                 <string>true</string>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>chown</key>
 					<array>
 					</array>

--- a/Configurations/ConfigAuthorizationTimeMachine.pkg.recipe
+++ b/Configurations/ConfigAuthorizationTimeMachine.pkg.recipe
@@ -43,10 +43,10 @@
 			<dict>
                 <key>force_pkg_build</key>
                 <string>true</string>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>chown</key>
 					<array>
 					</array>

--- a/Configurations/ConfigAutoLogin.pkg.recipe
+++ b/Configurations/ConfigAutoLogin.pkg.recipe
@@ -44,10 +44,10 @@
 			<dict>
                 <key>force_pkg_build</key>
                 <string>true</string>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>chown</key>
 					<array>
 					</array>

--- a/Configurations/ConfigBackToMyMac.pkg.recipe
+++ b/Configurations/ConfigBackToMyMac.pkg.recipe
@@ -43,10 +43,10 @@
 			<dict>
                 <key>force_pkg_build</key>
                 <string>true</string>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>chown</key>
 					<array>
 					</array>

--- a/Configurations/ConfigBonjourBrowsing.pkg.recipe
+++ b/Configurations/ConfigBonjourBrowsing.pkg.recipe
@@ -43,10 +43,10 @@
 			<dict>
                 <key>force_pkg_build</key>
                 <string>true</string>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>chown</key>
 					<array>
 					</array>

--- a/Configurations/ConfigDiagnostics.pkg.recipe
+++ b/Configurations/ConfigDiagnostics.pkg.recipe
@@ -43,10 +43,10 @@
 			<dict>
                 <key>force_pkg_build</key>
                 <string>true</string>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>chown</key>
 					<array>
 					</array>

--- a/Configurations/ConfigDockfixup.pkg.recipe
+++ b/Configurations/ConfigDockfixup.pkg.recipe
@@ -43,10 +43,10 @@
 			<dict>
                 <key>force_pkg_build</key>
                 <string>true</string>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>chown</key>
 					<array>
 					</array>

--- a/Configurations/ConfigEnergySaver.pkg.recipe
+++ b/Configurations/ConfigEnergySaver.pkg.recipe
@@ -43,10 +43,10 @@
 			<dict>
                 <key>force_pkg_build</key>
                 <string>true</string>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>chown</key>
 					<array>
 					</array>

--- a/Configurations/ConfigGatekeeper.pkg.recipe
+++ b/Configurations/ConfigGatekeeper.pkg.recipe
@@ -43,10 +43,10 @@
 			<dict>
                 <key>force_pkg_build</key>
                 <string>true</string>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>chown</key>
 					<array>
 					</array>

--- a/Configurations/ConfigGestureMovie.pkg.recipe
+++ b/Configurations/ConfigGestureMovie.pkg.recipe
@@ -43,10 +43,10 @@
 			<dict>
                 <key>force_pkg_build</key>
                 <string>true</string>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>chown</key>
 					<array>
 					</array>

--- a/Configurations/ConfigLocalAdmin.pkg.recipe
+++ b/Configurations/ConfigLocalAdmin.pkg.recipe
@@ -44,10 +44,10 @@
 			<dict>
                 <key>force_pkg_build</key>
                 <string>true</string>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/Configurations/ConfigLocalUser.pkg.recipe
+++ b/Configurations/ConfigLocalUser.pkg.recipe
@@ -44,10 +44,10 @@
 			<dict>
                 <key>force_pkg_build</key>
                 <string>true</string>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/Configurations/ConfigLocale.pkg.recipe
+++ b/Configurations/ConfigLocale.pkg.recipe
@@ -43,10 +43,10 @@
 			<dict>
                 <key>force_pkg_build</key>
                 <string>true</string>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>chown</key>
 					<array>
 					</array>

--- a/Configurations/ConfigMunki.pkg.recipe
+++ b/Configurations/ConfigMunki.pkg.recipe
@@ -43,10 +43,10 @@
 			<dict>
                 <key>force_pkg_build</key>
                 <string>true</string>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>chown</key>
 					<array>
 					</array>

--- a/Configurations/ConfigRegistrationWizard.pkg.recipe
+++ b/Configurations/ConfigRegistrationWizard.pkg.recipe
@@ -43,10 +43,10 @@
 			<dict>
                 <key>force_pkg_build</key>
                 <string>true</string>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/Configurations/ConfigRemoteLogin.pkg.recipe
+++ b/Configurations/ConfigRemoteLogin.pkg.recipe
@@ -44,10 +44,10 @@
 			<dict>
                 <key>force_pkg_build</key>
                 <string>true</string>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/Configurations/ConfigRemoteManagement.pkg.recipe
+++ b/Configurations/ConfigRemoteManagement.pkg.recipe
@@ -51,10 +51,10 @@
 			<dict>
                 <key>force_pkg_build</key>
                 <string>true</string>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/Configurations/ConfigReposado.pkg.recipe
+++ b/Configurations/ConfigReposado.pkg.recipe
@@ -43,10 +43,10 @@
 			<dict>
                 <key>force_pkg_build</key>
                 <string>true</string>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>chown</key>
 					<array>
 					</array>

--- a/Configurations/ConfigScreenSaver.pkg.recipe
+++ b/Configurations/ConfigScreenSaver.pkg.recipe
@@ -43,10 +43,10 @@
 			<dict>
                 <key>force_pkg_build</key>
                 <string>true</string>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>chown</key>
 					<array>
 					</array>

--- a/Configurations/ConfigSetupAssistant.pkg.recipe
+++ b/Configurations/ConfigSetupAssistant.pkg.recipe
@@ -43,10 +43,10 @@
 			<dict>
                 <key>force_pkg_build</key>
                 <string>true</string>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/Configurations/ConfigSoftwareUpdate.pkg.recipe
+++ b/Configurations/ConfigSoftwareUpdate.pkg.recipe
@@ -43,10 +43,10 @@
 			<dict>
                 <key>force_pkg_build</key>
                 <string>true</string>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>chown</key>
 					<array>
 					</array>

--- a/Configurations/ConfigStreams.pkg.recipe
+++ b/Configurations/ConfigStreams.pkg.recipe
@@ -43,10 +43,10 @@
 			<dict>
                 <key>force_pkg_build</key>
                 <string>true</string>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/Configurations/ConfigWebSharing.pkg.recipe
+++ b/Configurations/ConfigWebSharing.pkg.recipe
@@ -43,10 +43,10 @@
 			<dict>
                 <key>force_pkg_build</key>
                 <string>true</string>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>chown</key>
 					<array>
 					</array>

--- a/Configurations/ConfigiCloud.pkg.recipe
+++ b/Configurations/ConfigiCloud.pkg.recipe
@@ -43,10 +43,10 @@
 			<dict>
                 <key>force_pkg_build</key>
                 <string>true</string>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>chown</key>
 					<array>
 					</array>


### PR DESCRIPTION
`pkgname` is [intended](https://github.com/autopkg/autopkg/blob/e36d5cba2823dbdfcb69a41a38b1aef9fb76121c/Code/autopkgserver/autopkgserver#L47) to be in the `pkg_request` dictionary, not as a standalone argument for [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator).